### PR TITLE
REST QoSPositionKpiReply now works on current server JSON Object stream format.

### DIFF
--- a/rest/.gitignore
+++ b/rest/.gitignore
@@ -1,0 +1,7 @@
+*.orig
+*.swp
+*.vs
+.DS_Store
+obj
+lib
+bin

--- a/rest/EngineTests/EngineTests.csproj
+++ b/rest/EngineTests/EngineTests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="nunit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MatchingEngineSDKRestLibrary\MatchingEngineSDKRestLibrary.csproj" />
+  </ItemGroup>
+</Project>

--- a/rest/EngineTests/UnitTest1.cs
+++ b/rest/EngineTests/UnitTest1.cs
@@ -1,0 +1,152 @@
+using NUnit.Framework;
+using DistributedMatchEngine;
+using System.IO;
+using System.Text;
+using System;
+
+namespace Tests
+{
+  public class Tests
+  {
+    [SetUp]
+    public void Setup()
+    {
+    }
+
+    private MemoryStream getMemoryStream(string jsonStr)
+    {
+      var ms = new MemoryStream(Encoding.UTF8.GetBytes(jsonStr));
+      return ms;
+    }
+
+    /**
+     * Basic equivalence tests for the QosPositionKpiStream internal JSON block parser.
+     */
+    [Test]
+    public void Test1()
+    {
+      QosPositionKpiStream streamParser;
+      var js1 = "{ 'foo' = 1 }";
+      streamParser = new QosPositionKpiStream(getMemoryStream(js1));
+
+      string parsed;
+      parsed = streamParser.ParseJsonBlock();
+      Assert.AreEqual(js1, parsed);
+
+      js1 = @"{ [{""foo"": ""2""}, {'bar' = 3}, { 'doot': '$2' }] }";
+      streamParser = new QosPositionKpiStream(getMemoryStream(js1));
+      parsed = streamParser.ParseJsonBlock();
+      Assert.AreEqual(js1, parsed);
+
+      var js2 = @"{ [{""foo"": ""2""}, {'bar' = 3}, { 'doot': '$2' }] }{ [{""foo"": ""2""}, {'bar' = 3}, { 'doot': '$2' }] }";
+      streamParser = new QosPositionKpiStream(getMemoryStream(js2));
+
+      for (int i = 0; i < 2; i++)
+      {
+        parsed = streamParser.ParseJsonBlock();
+        Assert.AreEqual(js1, parsed);
+      }
+      streamParser.Dispose();
+    }
+
+    /**
+     * Basic equivalence tests for the QosPositionKpiStream internal JSON block parser.
+     * An escape char.
+     */
+    [Test]
+    public void TestQosPositionStreamEscape()
+    {
+      QosPositionKpiStream streamParser;
+      var js1 = @"{ [{""foo\u005C"": ""2""}, {'bar' = 3}, { 'doot': '$2' }] }";
+
+      string parsed;
+      streamParser = new QosPositionKpiStream(getMemoryStream(js1));
+      parsed = streamParser.ParseJsonBlock();
+      Assert.AreEqual(js1, parsed);
+      streamParser.Dispose();
+    }
+
+    /**
+     * Basic equivalence tests for the QosPositionKpiStream internal JSON block parser.
+     */
+    [Test]
+    public void TestQosPositionStream()
+    {
+      QosPositionKpiStream streamParser;
+      string parsed;
+      string js1 = @"{
+ ""result"": {
+  ""ver"": 0,
+  ""status"": ""RS_SUCCESS"",
+  ""position_results"": [
+   {
+    ""positionid"": ""1"",
+    ""gps_location"": {
+     ""latitude"": 50.11729018260935,
+     ""longitude"": 8.576783680147576,
+     ""horizontal_accuracy"": 0,
+     ""vertical_accuracy"": 0,
+     ""altitude"": 0,
+     ""course"": 0,
+     ""speed"": 0,
+     ""timestamp"": {
+      ""seconds"": ""63703198734"",
+      ""nanos"": 863000000
+     }
+},
+    ""dluserthroughput_min"": 0,
+    ""dluserthroughput_avg"": 31.561584,
+    ""dluserthroughput_max"": 121.52567,
+    ""uluserthroughput_min"": 0,
+    ""uluserthroughput_avg"": 18.889288,
+    ""uluserthroughput_max"": 51.594624,
+    ""latency_min"": 47.231102,
+    ""latency_avg"": 0,
+    ""latency_max"": 0
+   },
+   {
+    ""positionid"": ""2"",
+    ""gps_location"": {
+     ""latitude"": 50.124580365218705,
+     ""longitude"": 8.571467360295152,
+     ""horizontal_accuracy"": 0,
+     ""vertical_accuracy"": 0,
+     ""altitude"": 0,
+     ""course"": 0,
+     ""speed"": 0,
+     ""timestamp"": {
+      ""seconds"": ""63703198734"",
+      ""nanos"": 863000000
+     }
+    },
+    ""dluserthroughput_min"": 0,
+    ""dluserthroughput_avg"": 41.597435,
+    ""dluserthroughput_max"": 99.60402,
+    ""uluserthroughput_min"": 0,
+    ""uluserthroughput_avg"": 12.110276,
+    ""uluserthroughput_max"": 37.700558,
+    ""latency_min"": 47.231102,
+    ""latency_avg"": 0,
+    ""latency_max"": 0
+   }
+  ]
+ }
+}";
+      streamParser = new QosPositionKpiStream(getMemoryStream(js1));
+      parsed = streamParser.ParseJsonBlock();
+
+      // Light existance pass:
+      streamParser = new QosPositionKpiStream(getMemoryStream(js1), 15000);
+      foreach (var reply in streamParser)
+      {
+        Assert.AreEqual(ReplyStatus.RS_SUCCESS, reply.status);
+        Assert.AreEqual(2, reply.position_results.Length);
+        Assert.AreEqual(50.11729018260935, reply.position_results[0].gps_location.latitude);
+        Assert.AreEqual(8.576783680147576, reply.position_results[0].gps_location.longitude);
+        Assert.AreEqual(47.231102f, reply.position_results[0].latency_min); // Not "very" exact.
+      }
+      Assert.AreEqual(js1, parsed);
+      streamParser.Dispose();
+    }
+  }
+}

--- a/rest/LICENSE.txt
+++ b/rest/LICENSE.txt
@@ -1,0 +1,14 @@
+Copyright 2019 MobiledgeX, Inc. All rights and licenses reserved.
+MobiledgeX, Inc. 156 2nd Street #408, San Francisco, CA 94105
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/rest/Makefile
+++ b/rest/Makefile
@@ -7,7 +7,7 @@ BINOUT := $(APPLIBBASE)/lib
 SOLUTIONLOG := /tmp/$(VSPROJECTROOT)_out.log
 PUBLISHLOG := /tmp/nuget_out.log
 
-REST_SDK_VERSION=1.4.10
+REST_SDK_VERSION=1.4.11
 NUGET_RELEASE_SERVER := https://artifactory.mobiledgex.net/artifactory/nuget-releases/
 
 all: packageRestore build-all

--- a/rest/MatchingEngineSDK.sln
+++ b/rest/MatchingEngineSDK.sln
@@ -5,6 +5,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MatchingEngineSDKRestLibrar
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RestSample", "RestSample\RestSample.csproj", "{B9CA0E3F-F423-4FEE-B909-96D9ECA1F0AE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EngineTests", "EngineTests\EngineTests.csproj", "{1865CADD-B9AF-43BD-991C-9B68D1677809}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -19,10 +21,14 @@ Global
 		{B9CA0E3F-F423-4FEE-B909-96D9ECA1F0AE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B9CA0E3F-F423-4FEE-B909-96D9ECA1F0AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B9CA0E3F-F423-4FEE-B909-96D9ECA1F0AE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1865CADD-B9AF-43BD-991C-9B68D1677809}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1865CADD-B9AF-43BD-991C-9B68D1677809}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1865CADD-B9AF-43BD-991C-9B68D1677809}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1865CADD-B9AF-43BD-991C-9B68D1677809}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		description = MatchingEngineSDK Library based on REST backend
-		version = 1.4.10
+		version = 1.4.11
 		Policies = $0
 		$0.DotNetNamingPolicy = $1
 		$1.DirectoryNamespaceAssociation = PrefixedHierarchical

--- a/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
+++ b/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
@@ -286,7 +286,7 @@ namespace DistributedMatchEngine
         dev_name = developerName,
         app_name = appName,
         app_vers = appVersion,
-        auth_token= authToken
+        auth_token = authToken
       };
     }
 
@@ -378,9 +378,6 @@ namespace DistributedMatchEngine
       {
         return null;
       }
-
-      jsonStr = Util.StreamToString(responseStream);
-      responseStream.Position = 0;
 
       DataContractJsonSerializer deserializer = new DataContractJsonSerializer(typeof(VerifyLocationReply));
       VerifyLocationReply reply = (VerifyLocationReply)deserializer.ReadObject(responseStream);
@@ -528,7 +525,7 @@ namespace DistributedMatchEngine
       return reply;
     }
 
-    public QosPositionRequest CreateQosPositionRequest(List<QosPosition> QosPositions)
+    public QosPositionRequest CreateQosPositionRequest(List<QosPosition> QosPositions, Int32 lteCategory, BandSelection bandSelection)
     {
       if (sessionCookie == null)
       {
@@ -539,11 +536,13 @@ namespace DistributedMatchEngine
       {
         ver = 1,
         positions = QosPositions.ToArray(),
-        session_cookie = this.sessionCookie
+        session_cookie = this.sessionCookie,
+        lte_category = lteCategory,
+        band_selection = bandSelection
       };
     }
 
-    public async Task<QosPositionKpiStreamReply> GetQosPositionKpi(string host, uint port, QosPositionRequest request)
+    public async Task<QosPositionKpiStream> GetQosPositionKpi(string host, uint port, QosPositionRequest request)
     {
       DataContractJsonSerializer serializer = new DataContractJsonSerializer(typeof(QosPositionRequest));
       MemoryStream ms = new MemoryStream();
@@ -551,14 +550,14 @@ namespace DistributedMatchEngine
       string jsonStr = Util.StreamToString(ms);
 
       Stream responseStream = await PostRequest(CreateUri(host, port) + qospositionkpiAPI, jsonStr);
-      if (responseStream == null || !responseStream.CanRead)
+      if (responseStream == null || !responseStream.CanRead || responseStream.Length == 0)
       {
         return null;
       }
 
-      DataContractJsonSerializer deserializer = new DataContractJsonSerializer(typeof(QosPositionKpiStreamReply));
-      QosPositionKpiStreamReply streamReply = (QosPositionKpiStreamReply)deserializer.ReadObject(responseStream);
-      return streamReply;
+      var qosPositionKpiStream = new QosPositionKpiStream(responseStream);
+
+      return qosPositionKpiStream;
     }
 
   };

--- a/rest/MatchingEngineSDKRestLibrary/MatchingEngineSDKRestLibrary.csproj
+++ b/rest/MatchingEngineSDKRestLibrary/MatchingEngineSDKRestLibrary.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <ReleaseVersion>1.4.10</ReleaseVersion>
+    <ReleaseVersion>1.4.11</ReleaseVersion>
     <PackOnBuild>true</PackOnBuild>
-    <PackageVersion>1.4.10</PackageVersion>
+    <PackageVersion>1.4.11</PackageVersion>
     <Authors>MobiledgeX, Inc.</Authors>
     <Description>MobiledgeX MatchingEngineSDK Library</Description>
     <Owners>MobiledgeX, Inc.</Owners>
@@ -12,8 +12,8 @@
     <Title>MobiledgeX MatchingEngineSDK Rest Library</Title>
     <PackageId>MobiledgeX.MatchingEngineRestSDKLibrary</PackageId>
     <PackageTags>MobiledgeX MatchingEngine</PackageTags>
-    <AssemblyVersion>1.4.10</AssemblyVersion>
-    <FileVersion>1.4.10</FileVersion>
+    <AssemblyVersion>1.4.11</AssemblyVersion>
+    <FileVersion>1.4.11</FileVersion>
     <Copyright>Copyright 2019 MobiledgeX, Inc. All rights and licenses reserved.</Copyright>
   </PropertyGroup>
 

--- a/rest/MatchingEngineSDKRestLibrary/QosPosition.cs
+++ b/rest/MatchingEngineSDKRestLibrary/QosPosition.cs
@@ -13,6 +13,20 @@ namespace DistributedMatchEngine
   }
 
   [DataContract]
+  public class BandSelection
+  {
+    // Radio Access Technologies
+    [DataMember]
+    public string[] rat_2g;
+    [DataMember]
+    public string[] rat_3g;
+    [DataMember]
+    public string[] rat_4g;
+    [DataMember]
+    public string[] rat_5g;
+  }
+
+  [DataContract]
   public class QosPositionRequest
   {
     // API version
@@ -24,6 +38,12 @@ namespace DistributedMatchEngine
     // list of positions
     [DataMember]
     public QosPosition[] positions;
+    // client's device LTE category number, optional
+    [DataMember]
+    public Int32 lte_category;
+    // Band list used by the client, optional
+    [DataMember]
+    public BandSelection band_selection;
   }
 
   [DataContract]

--- a/rest/MatchingEngineSDKRestLibrary/QosPositionKpiStream.cs
+++ b/rest/MatchingEngineSDKRestLibrary/QosPositionKpiStream.cs
@@ -1,0 +1,232 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.Serialization.Json;
+using System.Text;
+
+namespace DistributedMatchEngine
+{
+
+  public class QosPositionKpiStream
+  {
+    StreamReader sr = null;
+    Stream jsonObjectStream;
+    DataContractJsonSerializer deserializer = new DataContractJsonSerializer(typeof(QosPositionKpiStreamReply));
+
+    const int msTimeoutDefault = 15000;
+
+    public QosPositionKpiStream(Stream jsonObjectStream, int msTimeout = msTimeoutDefault)
+    {
+      if (msTimeout < 0)
+      {
+        msTimeout = msTimeoutDefault;
+      }
+      this.jsonObjectStream = jsonObjectStream;
+      sr = GetStreamReader(msTimeout);
+    }
+
+    public StreamReader GetStreamReader(int msTimeout)
+    {
+      if (jsonObjectStream.CanTimeout)
+      {
+        jsonObjectStream.ReadTimeout = msTimeout;
+      }
+      sr = new StreamReader(jsonObjectStream, true); // Detect encoding.
+      return sr;
+    }
+
+    // skip '' blocks. Also skips escape chars.
+    public long skipCharQuote(StreamReader sr, StringBuilder sb)
+    {
+      long charsRead = 0;
+
+      int c;
+      bool esc = false;
+      while (sr.Peek() > -1 && !sr.EndOfStream)
+      {
+        c = sr.Read();
+        sb.Append(Char.ConvertFromUtf32(c));
+        charsRead++;
+
+        // Not a strict check
+        if (esc == true)
+        {
+          esc = false;
+          continue;
+        }
+        if (c == '\\')
+        {
+          esc = true;
+          continue;
+        }
+        else if (c == '\'')
+        {
+          return charsRead;
+        }
+      }
+
+      Console.Error.WriteLine("Hit end of stream while parsing for single quote char --> ' <--");
+      return charsRead;
+    }
+
+    // skip "" blocks. Also skips escape chars.
+    public long skipStringQuote(StreamReader sr, StringBuilder sb)
+    {
+      long charsRead = 0;
+
+      int c;
+      bool esc = false;
+      while (sr.Peek() > -1 && !sr.EndOfStream)
+      {
+        c = sr.Read();
+        sb.Append(Char.ConvertFromUtf32(c));
+        charsRead++;
+
+        // Not a strict check
+        if (esc == true)
+        {
+          esc = false;
+          continue;
+        }
+        if (c == '\\')
+        {
+          esc = true;
+          continue;
+        }
+        else if (c == '"')
+        {
+          return charsRead;
+        }
+      }
+
+      Console.Error.WriteLine("Hit end of stream while parsing for double quote char --> \" <--");
+      return charsRead;
+    }
+
+    // Very basic parser, this just chops out potential JSON strings from a stream, then hands it over
+    // to a full parser that operates on complete bounded JSON strings.
+    public string ParseJsonBlock()
+    {
+      int c = 0;
+      long charsRead = 0;
+      long quoteRead = 0;
+
+      StringBuilder objsb = null;
+      bool stopParsing = false;
+
+      var s = new Stack<int>();
+
+      while (sr.Peek() > -1 && !sr.EndOfStream)
+      {
+        if (stopParsing)
+        {
+          break;
+        }
+
+        c = sr.Read();
+        charsRead++;
+        string cs = Char.ConvertFromUtf32(c);
+
+        if (objsb == null)
+        {
+          objsb = new StringBuilder();
+        }
+        objsb.Append(cs);
+
+        switch (c)
+        {
+          case '{':
+            s.Push(c);
+            break;
+          case '}':
+            if (s.Peek() == '{')
+            {
+              s.Pop();
+              if (s.Count == 0)
+              {
+                stopParsing = true;
+                break;
+              }
+            }
+            else
+            {
+              Console.Error.WriteLine("This is not valid JSON: " + c + ", position: " + charsRead);
+              break;
+            }
+            break;
+          case '[':
+            s.Push(c);
+            break;
+          case ']':
+            if (s.Peek() == '[')
+            {
+              s.Pop();
+            }
+            else
+            {
+              Console.Error.WriteLine("This is not valid JSON: " + c + ", position: " + charsRead);
+            }
+            break;
+          case '\'':
+            quoteRead = skipCharQuote(sr, objsb);
+            charsRead += quoteRead;
+            break;
+          case '"':
+            quoteRead = skipStringQuote(sr, objsb);
+            charsRead += quoteRead;
+            break;
+        }
+      }
+
+
+      if (s.Count > 0) // Unbalanced.
+      {
+        Console.Error.WriteLine("Parse error. EndOfStream encountered while parsing.");
+        return null;
+      }
+
+      if (s.Count == 0 && stopParsing)
+      {
+        return objsb.ToString(); // Parsed.
+      }
+      else
+      {
+        return null;
+      }
+    }
+
+    public IEnumerator<QosPositionKpiReply> GetEnumerator()
+    {
+      while (sr.Peek() > -1 && !sr.EndOfStream)
+      {
+        string qprJsonStr = ParseJsonBlock();
+
+        if (qprJsonStr != null)
+        {
+          byte[] byteArray = sr.CurrentEncoding.GetBytes(qprJsonStr);
+          MemoryStream ms = new MemoryStream(byteArray);
+          QosPositionKpiStreamReply reply = null;
+          try
+          {
+            reply = deserializer.ReadObject(ms) as QosPositionKpiStreamReply;
+          } catch (Exception e)
+          {
+            Console.Error.WriteLine(e.StackTrace);
+            Console.Error.WriteLine(reply.error);
+          }
+
+          // Could be null
+          yield return reply.result;
+        }
+      }
+    }
+
+    public void Dispose()
+    {
+      jsonObjectStream.Dispose();
+      sr.Dispose();
+    }
+
+  }
+
+}

--- a/rest/MatchingEngineSDKRestLibrary/Util.cs
+++ b/rest/MatchingEngineSDKRestLibrary/Util.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Runtime.Serialization;
 using System.Threading.Tasks;
 
 namespace DistributedMatchEngine
@@ -20,9 +19,9 @@ namespace DistributedMatchEngine
       return jsonStr;
     }
 
+    // FIXME: This function needs per device customization.
     public async static Task<Loc> GetLocationFromDevice()
     {
-      // FIXME: Do async device location.
       long timeLongMs = new DateTimeOffset(DateTime.UtcNow).ToUnixTimeMilliseconds();
       long seconds = timeLongMs / 1000;
       int nanoSec = (int)(timeLongMs % 1000) * 1000000;

--- a/rest/RestSample/RestSample.csproj
+++ b/rest/RestSample/RestSample.csproj
@@ -4,9 +4,9 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
-    <ReleaseVersion>1.4.0</ReleaseVersion>
+    <ReleaseVersion>1.4.11</ReleaseVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MobiledgeX.MatchingEngineRestSDKLibrary" Version="1.4.10" />
+    <PackageReference Include="MobiledgeX.MatchingEngineRestSDKLibrary" Version="1.4.11" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
REST was broken due to the "real" DT QoS position server being used (and returning a stream of JSON objects). Since it doesn't follow the [{}, {}] JSON format, but instead a stream of {} {} objects that are maybe separated by time only, the only proper way to parse it is sit on the stream parsing until it looks like a JSON block resembling QoSPositionKpiSteamReply objects, that contain QoSPositionKpi per object.

Then, the normal DataContractJsonSerializer can deserialize that delimited stream. It gets confused otherwise, as it isn't valid JSON.

Unit tests and Sample code updated.

Unity to follow. Possibly in the same pull request branch.

Grpc is currently also broken.