### PR TITLE
EDGECLOUD-1396: DataMember enum rename workaround for iOS Unity.

### DIFF
--- a/rest/MatchingEngineSDKRestLibrary/AppCommon.cs
+++ b/rest/MatchingEngineSDKRestLibrary/AppCommon.cs
@@ -47,7 +47,14 @@ namespace DistributedMatchEngine
       }
       set
       {
-        proto = Enum.TryParse(value, out LProto lproto) ? lproto : LProto.L_PROTO_UNKNOWN;
+        try
+        {
+          proto = (LProto)Enum.Parse(typeof(LProto), value);
+        }
+        catch
+        {
+          proto = LProto.L_PROTO_UNKNOWN;
+        }
       }
     }
 

--- a/rest/MatchingEngineSDKRestLibrary/AppInstList.cs
+++ b/rest/MatchingEngineSDKRestLibrary/AppInstList.cs
@@ -94,7 +94,14 @@ namespace DistributedMatchEngine
       }
       set
       {
-        status = Enum.TryParse(value, out AIStatus rStatus) ? rStatus : AIStatus.AI_UNDEFINED;
+        try
+        {
+          status = (AIStatus)Enum.Parse(typeof(AIStatus), value);
+        }
+        catch
+        {
+          status = AIStatus.AI_UNDEFINED;
+        }
       }
     }
 

--- a/rest/MatchingEngineSDKRestLibrary/DynamicLocGroup.cs
+++ b/rest/MatchingEngineSDKRestLibrary/DynamicLocGroup.cs
@@ -73,9 +73,17 @@ namespace DistributedMatchEngine
       {
         return status.ToString();
       }
+
       set
       {
-        status = Enum.TryParse(value, out ReplyStatus replyStatus) ? replyStatus : ReplyStatus.RS_UNDEFINED;
+        try
+        {
+          status = (ReplyStatus)Enum.Parse(typeof(ReplyStatus), value);
+        }
+        catch
+        {
+          status = ReplyStatus.RS_UNDEFINED;
+        }
       }
     }
 

--- a/rest/MatchingEngineSDKRestLibrary/FindCloudlet.cs
+++ b/rest/MatchingEngineSDKRestLibrary/FindCloudlet.cs
@@ -64,7 +64,14 @@ namespace DistributedMatchEngine
       }
       set
       {
-        status = Enum.TryParse(value, out FindStatus findStatus) ? findStatus : FindStatus.FIND_UNKNOWN;
+        try
+        {
+          status = (FindStatus)Enum.Parse(typeof(FindStatus), value);
+        }
+        catch
+        {
+          status = FindStatus.FIND_UNKNOWN;
+        }
       }
     }
 

--- a/rest/MatchingEngineSDKRestLibrary/FqdnList.cs
+++ b/rest/MatchingEngineSDKRestLibrary/FqdnList.cs
@@ -78,7 +78,14 @@ namespace DistributedMatchEngine
       }
       set
       {
-        status = Enum.TryParse(value, out FLStatus flStatus) ? flStatus : FLStatus.FL_UNDEFINED;
+        try
+        {
+          status = (FLStatus)Enum.Parse(typeof(FLStatus), value);
+        }
+        catch
+        {
+          status = FLStatus.FL_UNDEFINED;
+        }
       }
     }
   }

--- a/rest/MatchingEngineSDKRestLibrary/GetLocation.cs
+++ b/rest/MatchingEngineSDKRestLibrary/GetLocation.cs
@@ -55,7 +55,14 @@ namespace DistributedMatchEngine
       }
       set
       {
-        status = Enum.TryParse(value, out LocStatus locStatus) ? locStatus : LocStatus.LOC_UNKNOWN;
+        try
+        {
+          status = (LocStatus)Enum.Parse(typeof(LocStatus), value);
+        }
+        catch
+        {
+          status = LocStatus.LOC_UNKNOWN;
+        }
       }
     }
 

--- a/rest/MatchingEngineSDKRestLibrary/MatchingEngineSDKRestLibrary.csproj
+++ b/rest/MatchingEngineSDKRestLibrary/MatchingEngineSDKRestLibrary.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <ReleaseVersion>1.4.14</ReleaseVersion>
+    <ReleaseVersion>1.4.15</ReleaseVersion>
     <PackOnBuild>true</PackOnBuild>
-    <PackageVersion>1.4.14</PackageVersion>
+    <PackageVersion>1.4.15</PackageVersion>
     <Authors>MobiledgeX, Inc.</Authors>
     <Description>MobiledgeX MatchingEngineSDK Library</Description>
     <Owners>MobiledgeX, Inc.</Owners>
@@ -12,8 +12,8 @@
     <Title>MobiledgeX MatchingEngineSDK Rest Library</Title>
     <PackageId>MobiledgeX.MatchingEngineRestSDKLibrary</PackageId>
     <PackageTags>MobiledgeX MatchingEngine</PackageTags>
-    <AssemblyVersion>1.4.14</AssemblyVersion>
-    <FileVersion>1.4.14</FileVersion>
+    <AssemblyVersion>1.4.15</AssemblyVersion>
+    <FileVersion>1.4.15</FileVersion>
     <Copyright>Copyright 2019 MobiledgeX, Inc. All rights and licenses reserved.</Copyright>
   </PropertyGroup>
 
@@ -25,7 +25,7 @@
     <OutputPath>lib\Release</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Json" Version="4.5.0" />
     <PackageReference Include="NuGet.Build.Packaging" Version="0.2.2" />
+    <PackageReference Include="System.Json" Version="4.6.0" />
   </ItemGroup>
 </Project>

--- a/rest/MatchingEngineSDKRestLibrary/QosPosition.cs
+++ b/rest/MatchingEngineSDKRestLibrary/QosPosition.cs
@@ -111,7 +111,14 @@ namespace DistributedMatchEngine
       }
       set
       {
-        status = Enum.TryParse(value, out ReplyStatus replyStatus) ? replyStatus : ReplyStatus.RS_UNDEFINED;
+        try
+        {
+          status = (ReplyStatus)Enum.Parse(typeof(ReplyStatus), value);
+        }
+        catch
+        {
+          status = ReplyStatus.RS_UNDEFINED;
+        }
       }
     }
 

--- a/rest/MatchingEngineSDKRestLibrary/RegisterClient.cs
+++ b/rest/MatchingEngineSDKRestLibrary/RegisterClient.cs
@@ -54,7 +54,14 @@ namespace DistributedMatchEngine
       }
       set
       {
-        status = Enum.TryParse(value, out ReplyStatus replyStatus) ? replyStatus : ReplyStatus.RS_UNDEFINED;
+        try
+        {
+          status = (ReplyStatus)Enum.Parse(typeof(ReplyStatus), value);
+        }
+        catch
+        {
+          status = ReplyStatus.RS_UNDEFINED;
+        }
       }
     }
 

--- a/rest/MatchingEngineSDKRestLibrary/VerifyLocation.cs
+++ b/rest/MatchingEngineSDKRestLibrary/VerifyLocation.cs
@@ -72,7 +72,14 @@ namespace DistributedMatchEngine
       }
       set
       {
-        tower_status = Enum.TryParse(value, out TowerStatus towerStatus) ? towerStatus : TowerStatus.TOWER_UNKNOWN;
+        try
+        {
+          tower_status = (TowerStatus)Enum.Parse(typeof(TowerStatus), value);
+        }
+        catch
+        {
+          tower_status = TowerStatus.TOWER_UNKNOWN;
+        }
       }
     }
 
@@ -87,7 +94,14 @@ namespace DistributedMatchEngine
       }
       set
       {
-        gps_location_status = Enum.TryParse(value, out GPSLocationStatus gpsLocation) ? gpsLocation : GPSLocationStatus.LOC_UNKNOWN;
+        try
+        {
+          gps_location_status = (GPSLocationStatus)Enum.Parse(typeof(GPSLocationStatus), value);
+        }
+        catch
+        {
+          gps_location_status = GPSLocationStatus.LOC_UNKNOWN;
+        }
       }
     }
 

--- a/rest/RestSample/RestSample.cs
+++ b/rest/RestSample/RestSample.cs
@@ -230,7 +230,8 @@ namespace RestSample
           }
           if (verifyLocationReply != null)
           {
-            Console.WriteLine("VerifyLocation Reply: " + verifyLocationReply.gps_location_status);
+            Console.WriteLine("VerifyLocation Reply GPS location status: " + verifyLocationReply.gps_location_status);
+            Console.WriteLine("VerifyLocation Reply Tower Status: " + verifyLocationReply.tower_status);
           }
         }
         catch (HttpException httpe)

--- a/rest/RestSample/RestSample.csproj
+++ b/rest/RestSample/RestSample.csproj
@@ -7,7 +7,7 @@
     <ReleaseVersion>1.4.14</ReleaseVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MobiledgeX.MatchingEngineRestSDKLibrary" Version="1.4.14" />
+    <PackageReference Include="MobiledgeX.MatchingEngineRestSDKLibrary" Version="1.4.15" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MatchingEngineSDKRestLibrary\MatchingEngineSDKRestLibrary.csproj" />


### PR DESCRIPTION
Found just before the hackathon: Android works, iOS doesn't. We take an Enum encoded as an Json String, and map it back to Enum. It ought to work, but doesn't anymore.

As promised, here is an ugly fix for the problem where we cannot redirect DataMember(Name="someOtherFieldName") to another field during deserialization via DataContract use. This is a Unity iOS cross compilation bug as far as I can tell, but one that doesn't have any other fix otherwise besides report the bug to Unity.

Essentially, we have to manually re-parse the incoming JSON stream. For most platforms (so far?), the reparse step doesn't happen, as the default enum value (0) isn't returned by the server, and is parsed correctly. If not parsed correctly, it remains default, and the SDK will then parse on that condition.

Also assuming output parameters with var declarations might stress the limits of C# spec level compliance, so moved back to try catch and Enum.Parse() instead of Enum.TryParse().

SDK version bump to 1.4.15 already pushed.

Repost here for a bit of background on just how broken all this is:
Json Parsers, Unity list:
 - System.Json: .Net 2.0 DataContracts: Enums broken, without double parsing.
 - System.Text.Json: .Net 3.0 doesn't use DataContracts anymore, object reflection only. Dependency tree hell since it's .Net 3.0, not .Net 2.0.
 - NewtonSoft Json.Net Unity: Doesn't work, and this one sits in Unity's Asset Store.
 - NewtonSoft Json.Net 12.0.1: Crashes in Unity. Newton works for Microsoft now.
 - Garner's Mini parser for QOS stream parsing: Still working, not a full JSON library.