### PR TITLE
EDGECLOUD-1763: Update carriername to use MCCMNC and wifi fallback.

### DIFF
--- a/rest/EngineTests/EngineTests.csproj
+++ b/rest/EngineTests/EngineTests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
-    <ReleaseVersion>1.4.18</ReleaseVersion>
+    <ReleaseVersion>1.4.19</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/rest/MatchingEngineSDK.sln
+++ b/rest/MatchingEngineSDK.sln
@@ -28,7 +28,7 @@ Global
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		description = MatchingEngineSDK Library based on REST backend
-		version = 1.4.18
+		version = 1.4.19
 		Policies = $0
 		$0.DotNetNamingPolicy = $1
 		$1.DirectoryNamespaceAssociation = PrefixedHierarchical

--- a/rest/MatchingEngineSDKRestLibrary/MatchingEngineSDKRestLibrary.csproj
+++ b/rest/MatchingEngineSDKRestLibrary/MatchingEngineSDKRestLibrary.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <ReleaseVersion>1.4.18</ReleaseVersion>
+    <ReleaseVersion>1.4.19</ReleaseVersion>
     <PackOnBuild>true</PackOnBuild>
-    <PackageVersion>1.4.18</PackageVersion>
+    <PackageVersion>1.4.19</PackageVersion>
     <Authors>MobiledgeX, Inc.</Authors>
     <Description>MobiledgeX MatchingEngineSDK Rest Library</Description>
     <Owners>MobiledgeX, Inc.</Owners>
@@ -12,8 +12,8 @@
     <Title>MobiledgeX MatchingEngineSDK Rest Library</Title>
     <PackageId>MobiledgeX.MatchingEngineSDKRestLibrary</PackageId>
     <PackageTags>MobiledgeX MatchingEngine</PackageTags>
-    <AssemblyVersion>1.4.18</AssemblyVersion>
-    <FileVersion>1.4.18</FileVersion>
+    <AssemblyVersion>1.4.19</AssemblyVersion>
+    <FileVersion>1.4.19</FileVersion>
     <Copyright>Copyright 2019 MobiledgeX, Inc. All rights and licenses reserved.</Copyright>
   </PropertyGroup>
 

--- a/rest/RestSample/RestSample.csproj
+++ b/rest/RestSample/RestSample.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
-    <ReleaseVersion>1.4.18</ReleaseVersion>
+    <ReleaseVersion>1.4.19</ReleaseVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MobiledgeX.MatchingEngineRestSDKLibrary" Version="1.4.15" />


### PR DESCRIPTION
CSharp version. Same logic as Android. Bump to 1.4.19. Not yet pushed to artifactory.