### PR TITLE
Default to Proximity Mode. Performance tests only goes to 3 by default now. Fix NetTest issue with dead sites if FindCloudlet told to return everything with blank carrier.

### DIFF
--- a/rest/MatchingEngineSDK.sln
+++ b/rest/MatchingEngineSDK.sln
@@ -28,7 +28,7 @@ Global
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		description = MatchingEngineSDK Library based on REST backend
-		version = 2.0.1
+		version = 2.0.2
 		Policies = $0
 		$0.DotNetNamingPolicy = $1
 		$1.DirectoryNamespaceAssociation = PrefixedHierarchical

--- a/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
+++ b/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
@@ -749,9 +749,9 @@ namespace DistributedMatchEngine
       };
     }
 
-    private NetTest.Site InitHttpSite(AppPort appPort, Appinstance appinstance)
+    private NetTest.Site InitHttpSite(AppPort appPort, Appinstance appinstance, int numSamples = NetTest.Site.DEFAULT_NUM_SAMPLES)
     {
-      NetTest.Site site = new NetTest.Site(numSamples: 10);
+      NetTest.Site site = new NetTest.Site(numSamples: numSamples);
 
       int port = appPort.public_port;
       string host = appPort.fqdn_prefix + appinstance.fqdn;
@@ -761,9 +761,9 @@ namespace DistributedMatchEngine
       return site;
     }
 
-    private NetTest.Site InitTcpSite(AppPort appPort, Appinstance appinstance)
+    private NetTest.Site InitTcpSite(AppPort appPort, Appinstance appinstance, int numSamples = NetTest.Site.DEFAULT_NUM_SAMPLES)
     {
-      NetTest.Site site = new NetTest.Site(numSamples: 10);
+      NetTest.Site site = new NetTest.Site(numSamples: numSamples);
 
       site.host = appPort.fqdn_prefix + appinstance.fqdn;
       site.port = appPort.public_port;
@@ -772,9 +772,9 @@ namespace DistributedMatchEngine
       return site;
     }
 
-    private NetTest.Site InitUdpSite(AppPort appPort, Appinstance appinstance)
+    private NetTest.Site InitUdpSite(AppPort appPort, Appinstance appinstance, int numSamples = NetTest.Site.DEFAULT_NUM_SAMPLES)
     {
-      NetTest.Site site = new NetTest.Site(testType: NetTest.TestType.PING, numSamples: 10);
+      NetTest.Site site = new NetTest.Site(testType: NetTest.TestType.PING, numSamples: numSamples);
 
       site.host = appPort.fqdn_prefix + appinstance.fqdn;
       site.port = appPort.public_port;
@@ -784,7 +784,7 @@ namespace DistributedMatchEngine
     }
 
     // Helper function for FindCloudlet
-    private NetTest.Site[] CreateSitesFromAppInstReply(AppInstListReply reply)
+    private NetTest.Site[] CreateSitesFromAppInstReply(AppInstListReply reply, int numSamples = NetTest.Site.DEFAULT_NUM_SAMPLES)
     {
       List<NetTest.Site> sites = new List<NetTest.Site>();
 
@@ -804,16 +804,16 @@ namespace DistributedMatchEngine
             case LProto.L_PROTO_TCP:
               if (appPort.path_prefix == null || appPort.path_prefix == "")
               {
-                sites.Add(InitTcpSite(appPort, appinstance));
+                sites.Add(InitTcpSite(appPort, appinstance, numSamples: numSamples));
               }
               else
               {
-                sites.Add(InitHttpSite(appPort, appinstance));
+                sites.Add(InitHttpSite(appPort, appinstance, numSamples: numSamples));
               }
               break;
 
             case LProto.L_PROTO_UDP:
-              sites.Add(InitUdpSite(appPort, appinstance));
+              sites.Add(InitUdpSite(appPort, appinstance, numSamples: numSamples));
               break;
 
             default:
@@ -826,7 +826,7 @@ namespace DistributedMatchEngine
     }
 
     // FindCloudlet with GetAppInstList and NetTest
-    public async Task<FindCloudletReply> FindCloudlet(string host, uint port, FindCloudletRequest request, FindCloudletMode mode = FindCloudletMode.PERFORMANCE)
+    public async Task<FindCloudletReply> FindCloudlet(string host, uint port, FindCloudletRequest request, FindCloudletMode mode = FindCloudletMode.PROXIMITY)
     {
       if (melMessaging.IsMelEnabled())
       {

--- a/rest/MatchingEngineSDKRestLibrary/MatchingEngineSDKRestLibrary.csproj
+++ b/rest/MatchingEngineSDKRestLibrary/MatchingEngineSDKRestLibrary.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <ReleaseVersion>2.0.1</ReleaseVersion>
+    <ReleaseVersion>2.0.2</ReleaseVersion>
     <PackOnBuild>true</PackOnBuild>
-    <PackageVersion>2.0.1</PackageVersion>
+    <PackageVersion>2.0.2</PackageVersion>
     <Authors>MobiledgeX, Inc.</Authors>
     <Description>MobiledgeX MatchingEngineSDK Rest Library</Description>
     <Owners>MobiledgeX, Inc.</Owners>
@@ -12,8 +12,8 @@
     <Title>MobiledgeX MatchingEngineSDK Rest Library</Title>
     <PackageId>MobiledgeX.MatchingEngineSDKRestLibrary</PackageId>
     <PackageTags>MobiledgeX MatchingEngine</PackageTags>
-    <AssemblyVersion>2.0.1</AssemblyVersion>
-    <FileVersion>2.0.1</FileVersion>
+    <AssemblyVersion>2.0.2</AssemblyVersion>
+    <FileVersion>2.0.2</FileVersion>
     <Copyright>Copyright 2019 MobiledgeX, Inc. All rights and licenses reserved.</Copyright>
   </PropertyGroup>
 

--- a/rest/MatchingEngineSDKRestLibrary/PerformanceMetrics/NetTest.cs
+++ b/rest/MatchingEngineSDKRestLibrary/PerformanceMetrics/NetTest.cs
@@ -49,15 +49,16 @@ namespace DistributedMatchEngine.PerformanceMetrics
       public TestType testType;
 
       int idx;
-      int size;
+      public int size { get; private set; }
       public double[] samples;
+      public const int DEFAULT_NUM_SAMPLES = 3;
 
       public double average;
       public double stddev;
 
       public Appinstance appInst;
 
-      public Site(TestType testType = TestType.CONNECT, int numSamples = 5)
+      public Site(TestType testType = TestType.CONNECT, int numSamples = DEFAULT_NUM_SAMPLES)
       {
         this.testType = testType;
         samples = new double[numSamples];
@@ -308,6 +309,11 @@ namespace DistributedMatchEngine.PerformanceMetrics
       var siteArr = sites.ToArray();
       Array.Sort(siteArr, delegate (Site x, Site y)
       {
+        if (x.size == 0 || y.size == 0 )
+        {
+          return x.size > y.size ? -1 : 1;
+        }
+
         if (x.average != y.average)
         {
           return x.average < y.average ? -1 : 1;

--- a/rest/RestSample/RestSample.csproj
+++ b/rest/RestSample/RestSample.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
-    <ReleaseVersion>2.0.1</ReleaseVersion>
+    <ReleaseVersion>2.0.2</ReleaseVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\MatchingEngineSDKRestLibrary\MatchingEngineSDKRestLibrary.csproj" />


### PR DESCRIPTION
Slavic Monster request: 10 test rounds is too high. Switch back to proximity mode as default.

Also fixed a sorting issue with dead sites.