### PR TITLE
Update for mel.aar. GetCookie() --> GetUid() again. Add GetVersion()

### DIFF
--- a/rest/MatchingEngineSDK.sln
+++ b/rest/MatchingEngineSDK.sln
@@ -28,7 +28,7 @@ Global
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		description = MatchingEngineSDK Library based on REST backend
-		version = 2.0.2
+		version = 2.0.3
 		Policies = $0
 		$0.DotNetNamingPolicy = $1
 		$1.DirectoryNamespaceAssociation = PrefixedHierarchical

--- a/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
+++ b/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
@@ -519,21 +519,22 @@ namespace DistributedMatchEngine
       }
 
       RegisterClientRequest oldRequest = request;
-      // MEL platform should have a UUID from a previous platform level registration, include it for App registration.
-      if (melMessaging.IsMelEnabled())
+      // Whether or not MEL is enabled, if UID is there, include it for App registration.
+      request = new RegisterClientRequest()
       {
-        request = new RegisterClientRequest()
-        {
           ver = oldRequest.ver,
           org_name = oldRequest.org_name,
           app_name = oldRequest.app_name,
           app_vers = oldRequest.app_vers,
           auth_token = oldRequest.auth_token,
           cell_id = oldRequest.cell_id,
-          unique_id = melMessaging.GetCookie(),
-          unique_id_type = "mel_unique_id", // FIXME: Unknown type.
           tags = oldRequest.tags
-        };
+      };
+      // MEL Enablement:
+      if (melMessaging.GetUid() != null && melMessaging.GetUid() != "")
+      {
+        request.unique_id_type = "Samsung:SamsungEnablingLayer";
+        request.unique_id = melMessaging.GetUid();
       }
 
       DataContractJsonSerializer deserializer = new DataContractJsonSerializer(typeof(RegisterClientReply));

--- a/rest/MatchingEngineSDKRestLibrary/MatchingEngineSDKRestLibrary.csproj
+++ b/rest/MatchingEngineSDKRestLibrary/MatchingEngineSDKRestLibrary.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <ReleaseVersion>2.0.2</ReleaseVersion>
+    <ReleaseVersion>2.0.3</ReleaseVersion>
     <PackOnBuild>true</PackOnBuild>
-    <PackageVersion>2.0.2</PackageVersion>
+    <PackageVersion>2.0.3</PackageVersion>
     <Authors>MobiledgeX, Inc.</Authors>
     <Description>MobiledgeX MatchingEngineSDK Rest Library</Description>
     <Owners>MobiledgeX, Inc.</Owners>
@@ -12,8 +12,8 @@
     <Title>MobiledgeX MatchingEngineSDK Rest Library</Title>
     <PackageId>MobiledgeX.MatchingEngineSDKRestLibrary</PackageId>
     <PackageTags>MobiledgeX MatchingEngine</PackageTags>
-    <AssemblyVersion>2.0.2</AssemblyVersion>
-    <FileVersion>2.0.2</FileVersion>
+    <AssemblyVersion>2.0.3</AssemblyVersion>
+    <FileVersion>2.0.3</FileVersion>
     <Copyright>Copyright 2019 MobiledgeX, Inc. All rights and licenses reserved.</Copyright>
   </PropertyGroup>
 

--- a/rest/MatchingEngineSDKRestLibrary/MelMessaging.cs
+++ b/rest/MatchingEngineSDKRestLibrary/MelMessaging.cs
@@ -4,17 +4,17 @@ namespace DistributedMatchEngine.Mel
 {
   public interface MelMessagingInterface
   {
-    bool IsMelReady();
     bool IsMelEnabled();
-    string GetCookie();
+    string GetMelVersion();
+    string GetUid();
     string SetLocationToken(string location_token, string app_name);
   }
 
   public class EmptyMelMessaging : MelMessagingInterface
   {
-    public bool IsMelReady() { return false;  }
     public bool IsMelEnabled() { return false; }
-    public string GetCookie() { return ""; }
+    public string GetMelVersion() { return ""; }
+    public string GetUid() { return ""; }
     public string SetLocationToken(string location_token, string app_name) { return ""; }
   }
 }

--- a/rest/RestSample/RestSample.csproj
+++ b/rest/RestSample/RestSample.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
-    <ReleaseVersion>2.0.2</ReleaseVersion>
+    <ReleaseVersion>2.0.3</ReleaseVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\MatchingEngineSDKRestLibrary\MatchingEngineSDKRestLibrary.csproj" />


### PR DESCRIPTION
Update C# SDK to what Android is right now.

Also like Android adds #3 support, which is even if MEL is not enabled, we can "activate" it by sending whatever UID we find on the MEL side of things to RegisterClient.