### PR TITLE
MEL needs a WiFi check, which was missing.

### DIFF
--- a/rest/EngineTests/EngineTests.csproj
+++ b/rest/EngineTests/EngineTests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
-    <ReleaseVersion>1.5.0</ReleaseVersion>
+    <ReleaseVersion>2.0.5</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/rest/Makefile
+++ b/rest/Makefile
@@ -20,7 +20,7 @@ BINOUT := $(APPLIBBASE)/lib
 SOLUTIONLOG := /tmp/$(VSPROJECTROOT)_out.log
 PUBLISHLOG := /tmp/nuget_out.log
 
-REST_SDK_VERSION=2.0.1
+REST_SDK_VERSION=2.0.5
 NUGET_RELEASE_SERVER := https://artifactory.mobiledgex.net/artifactory/nuget-releases/
 
 all: packageRestore build-all

--- a/rest/MatchingEngineSDK.sln
+++ b/rest/MatchingEngineSDK.sln
@@ -28,7 +28,7 @@ Global
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		description = MatchingEngineSDK Library based on REST backend
-		version = 2.0.4
+		version = 2.0.5
 		Policies = $0
 		$0.DotNetNamingPolicy = $1
 		$1.DirectoryNamespaceAssociation = PrefixedHierarchical

--- a/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
+++ b/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
@@ -834,7 +834,7 @@ namespace DistributedMatchEngine
     // FindCloudlet with GetAppInstList and NetTest
     public async Task<FindCloudletReply> FindCloudlet(string host, uint port, FindCloudletRequest request, FindCloudletMode mode = FindCloudletMode.PROXIMITY)
     {
-      if (melMessaging.IsMelEnabled())
+      if (melMessaging.IsMelEnabled() && !netInterface.HasWifi())
       {
         return await FindCloudletMelMode(host, port, request).ConfigureAwait(false);
       }

--- a/rest/MatchingEngineSDKRestLibrary/MatchingEngineSDKRestLibrary.csproj
+++ b/rest/MatchingEngineSDKRestLibrary/MatchingEngineSDKRestLibrary.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <ReleaseVersion>2.0.4</ReleaseVersion>
+    <ReleaseVersion>2.0.5</ReleaseVersion>
     <PackOnBuild>true</PackOnBuild>
-    <PackageVersion>2.0.4</PackageVersion>
+    <PackageVersion>2.0.5</PackageVersion>
     <Authors>MobiledgeX, Inc.</Authors>
     <Description>MobiledgeX MatchingEngineSDK Rest Library</Description>
     <Owners>MobiledgeX, Inc.</Owners>
@@ -12,8 +12,8 @@
     <Title>MobiledgeX MatchingEngineSDK Rest Library</Title>
     <PackageId>MobiledgeX.MatchingEngineSDKRestLibrary</PackageId>
     <PackageTags>MobiledgeX MatchingEngine</PackageTags>
-    <AssemblyVersion>2.0.4</AssemblyVersion>
-    <FileVersion>2.0.4</FileVersion>
+    <AssemblyVersion>2.0.5</AssemblyVersion>
+    <FileVersion>2.0.5</FileVersion>
     <Copyright>Copyright 2019 MobiledgeX, Inc. All rights and licenses reserved.</Copyright>
   </PropertyGroup>
 

--- a/rest/RestSample/RestSample.csproj
+++ b/rest/RestSample/RestSample.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
-    <ReleaseVersion>2.0.4</ReleaseVersion>
+    <ReleaseVersion>2.0.5</ReleaseVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\MatchingEngineSDKRestLibrary\MatchingEngineSDKRestLibrary.csproj" />


### PR DESCRIPTION
Must have lost the change somewhere, now back in, in 2.0.5. Already uploaded and tested. 

Every developer to test MEL has to flip WiFi off due to world wide SIP measures, so nothing changed otherwise.