### PR TITLE
EDGECLOUD-2843: Error with CellInfoNr in Unity Android SDK

### DIFF
--- a/rest/MatchingEngineSDKRestLibrary/CarrierInfo.cs
+++ b/rest/MatchingEngineSDKRestLibrary/CarrierInfo.cs
@@ -26,7 +26,7 @@ namespace DistributedMatchEngine
   {
     string GetCurrentCarrierName();
     string GetMccMnc();
-    UInt32 GetCellID();
+    ulong GetCellID();
   }
 
   public class EmptyCarrierInfo : CarrierInfo
@@ -41,7 +41,7 @@ namespace DistributedMatchEngine
       throw new NotImplementedException("Required CarrierInfo interface function: GetMccMnc() is not defined!");
     }
 
-    public UInt32 GetCellID()
+    public ulong GetCellID()
     {
       throw new NotImplementedException("Required CarrierInfo interface function: GetCellID() is not defined!");
     }

--- a/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
+++ b/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
@@ -256,7 +256,7 @@ namespace DistributedMatchEngine
       return uniqueID.GetUniqueID();
     }
 
-    public UInt32 GetCellID()
+    public ulong GetCellID()
     {
       return carrierInfo.GetCellID();
     }


### PR DESCRIPTION
GetCellID needs to return ulong instead of uint. 

The Unity Integration code had been calling `PlatformIntegrationUtil.Call<int>(cellIdentity, "getNci");`, but the actual Android code: `cellIdentityNr.getNci()` returns a long, not an int. The rest of the cellIdentity[].getCid() Android functions return ints (all nonnegative), so its easy enough to cast those as ulong.