### PR TITLE
EDGECLOUD-3081 MEL Use Android_ID if Samsung, but no MEL UID

### DIFF
--- a/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
+++ b/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
@@ -504,6 +504,27 @@ namespace DistributedMatchEngine
       return await RegisterClient(GenerateDmeHostAddress(), defaultDmeRestPort, request);
     }
 
+    private RegisterClientRequest UpdateRequestFoMel(RegisterClientRequest request)
+    {
+      string uid = melMessaging.GetUid();
+      string android_id = GetUniqueID();
+      string manufacturer = melMessaging.GetManufacturer();
+
+      if (uid != null && uid != "")
+      {
+        request.unique_id_type = "Samsung:SamsungEnablingLayer";
+        request.unique_id = melMessaging.GetUid();
+      }
+      else if (manufacturer != null && manufacturer.ToLower().Equals("samsung") &&
+               android_id != null && android_id.Length > 0)
+      {
+        request.unique_id_type = "Samsung:ANDROID_ID";
+        request.unique_id = android_id;
+      }
+
+      return request;
+    }
+
     public async Task<RegisterClientReply> RegisterClient(string host, uint port, RegisterClientRequest request)
     {
       RegisterClientRequest oldRequest = request;
@@ -518,12 +539,9 @@ namespace DistributedMatchEngine
         cell_id = oldRequest.cell_id,
         tags = oldRequest.tags
       };
+
       // MEL Enablement:
-      if (melMessaging.GetUid() != null && melMessaging.GetUid() != "")
-      {
-        request.unique_id_type = "Samsung:SamsungEnablingLayer";
-        request.unique_id = melMessaging.GetUid();
-      }
+      request = UpdateRequestFoMel(request);
 
       DataContractJsonSerializer serializer = new DataContractJsonSerializer(typeof(RegisterClientRequest));
       MemoryStream ms = new MemoryStream();

--- a/rest/MatchingEngineSDKRestLibrary/MelMessaging.cs
+++ b/rest/MatchingEngineSDKRestLibrary/MelMessaging.cs
@@ -8,6 +8,7 @@ namespace DistributedMatchEngine.Mel
     string GetMelVersion();
     string GetUid();
     string SetToken(string token, string app_name);
+    string GetManufacturer();
   }
 
   public class EmptyMelMessaging : MelMessagingInterface
@@ -16,5 +17,6 @@ namespace DistributedMatchEngine.Mel
     public string GetMelVersion() { return ""; }
     public string GetUid() { return ""; }
     public string SetToken(string token, string app_name) { return ""; }
+    public string GetManufacturer() { return ""; }
   }
 }


### PR DESCRIPTION
If Samsung, and No mel, use Android ID. Mirrors changes in Android MEL.