### PR TITLE
EDGECLOUD-3159: Log which DME is being used

### DIFF
--- a/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
+++ b/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
@@ -125,14 +125,12 @@ namespace DistributedMatchEngine
       TextWriter errorWriter = Console.Error;
       errorWriter.WriteLine(msg);
     }
-
     // Stdout:
     [ConditionalAttribute("DEBUG")]
     public static void D(string msg)
     {
       Console.WriteLine(msg);
     }
-
   }
 
   public enum OperatingSystem


### PR DESCRIPTION
Edited a couple log messages that were only being logged in Debug configurations. We want to see these in Release version for Unity SDK