### PR TITLE
EDGECLOUD-2958: DmeDnsException Getting Thrown in Unity Editor when Connected via Ethernet

### DIFF
--- a/rest/MatchingEngineSDKRestLibrary/GetConnectionUtil.cs
+++ b/rest/MatchingEngineSDKRestLibrary/GetConnectionUtil.cs
@@ -57,8 +57,27 @@ namespace DistributedMatchEngine
   {
     public MacNetworkInterfaceName()
     {
-      CELLULAR = new string[] { "en0" };
-      WIFI = new string[] { "en0" };
+      // en0 and en1 should be Wifi and Ethernet or vice versa
+      CELLULAR = new string[] { "en0", "en1" };
+      WIFI = new string[] { "en0", "en1" };
+    }
+  }
+
+  public class LinuxNetworkInterfaceName : NetworkInterfaceName
+  {
+    public LinuxNetworkInterfaceName()
+    {
+      CELLULAR = new string[] { "eth0", "wlan0" };
+      WIFI = new string[] { "eth0", "wlan0" };
+    }
+  }
+
+  public class Windows10NetworkInterfaceName : NetworkInterfaceName
+  {
+    public Windows10NetworkInterfaceName()
+    {
+      CELLULAR = new string[] { "Ethernet adapter Ethernet",  "Wireless LAN adapter Wi-Fi", "Ethernet", "WiFi" };
+      WIFI = new string[] { "Ethernet adapter Ethernet",  "Wireless LAN adapter Wi-Fi", "Ethernet", "WiFi" };
     }
   }
 


### PR DESCRIPTION
- "en0" and "en1" should be Wifi and Ethernet or vice versa for Macs
- Add support for Linux and Windows (for @LeonAdams's automation server)