### PR TITLE
change sslpolicyerror check to hasFlag instead of ==

### DIFF
--- a/rest/MatchingEngineSDKRestLibrary/GetConnectionHelper.cs
+++ b/rest/MatchingEngineSDKRestLibrary/GetConnectionHelper.cs
@@ -144,7 +144,7 @@ namespace DistributedMatchEngine
 
             // Check if the sender (eg. the specific sslStream) allows self signed server certs
             if (allowSelfSignedCerts) {
-              if (sslPolicyErrors == SslPolicyErrors.RemoteCertificateChainErrors && chain.ChainStatus[0].Status == X509ChainStatusFlags.UntrustedRoot) {
+              if (sslPolicyErrors.HasFlag(SslPolicyErrors.RemoteCertificateChainErrors) && chain.ChainStatus[0].Status == X509ChainStatusFlags.UntrustedRoot) {
                 Console.WriteLine("Self-signed server certificate allowed. Bypassing untrusted root");
                 return true;
               }


### PR DESCRIPTION
sslPolicyErrors is a bitwise combination of multiple enum values. So == does not work if there are multiple "flags" set. HasFlag is a more appropriate check