### PR TITLE
remove redundant word

### DIFF
--- a/rest/Doxygen/Doxyfile
+++ b/rest/Doxygen/Doxyfile
@@ -4,7 +4,7 @@
 # Project related configuration options
 #---------------------------------------------------------------------------
 DOXYFILE_ENCODING      = UTF-8
-PROJECT_NAME           = "C# SDK Documentation"
+PROJECT_NAME           = "C# SDK"
 PROJECT_NUMBER         =
 PROJECT_BRIEF          =
 PROJECT_LOGO           =


### PR DESCRIPTION
Doxygen generates PROJECT_NAME + "Documentation" for that title page that Loann pointed out. Remove that redundant word