### PR TITLE
EDGECLOUD-3583: Remove transition code to MEL with ports from server.

### DIFF
--- a/rest/Doxygen/Doxygen.csproj
+++ b/rest/Doxygen/Doxygen.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <RootNamespace>Doxygen</RootNamespace>
-    <ReleaseVersion>2.1.5</ReleaseVersion>
+    <ReleaseVersion>2.1.7</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugType>full</DebugType>

--- a/rest/EngineTests/EngineTests.csproj
+++ b/rest/EngineTests/EngineTests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
-    <ReleaseVersion>2.1.6</ReleaseVersion>
+    <ReleaseVersion>2.1.7</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/rest/Makefile
+++ b/rest/Makefile
@@ -20,7 +20,7 @@ BINOUT := $(APPLIBBASE)/lib
 SOLUTIONLOG := /tmp/$(VSPROJECTROOT)_out.log
 PUBLISHLOG := /tmp/nuget_out.log
 
-REST_SDK_VERSION=2.1.6
+REST_SDK_VERSION=2.1.7
 NUGET_RELEASE_SERVER := https://artifactory.mobiledgex.net/api/nuget/nuget-releases/
 
 DOXYGENROOT := Doxygen

--- a/rest/MatchingEngineSDK.sln
+++ b/rest/MatchingEngineSDK.sln
@@ -52,7 +52,7 @@ Global
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		description = MatchingEngineSDK Library based on REST backend
-		version = 2.1.6
+		version = 2.1.7
 		Policies = $0
 		$0.DotNetNamingPolicy = $1
 		$1.DirectoryNamespaceAssociation = PrefixedHierarchical

--- a/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
+++ b/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
@@ -867,16 +867,6 @@ namespace DistributedMatchEngine
       };
 
       fcReply.status = reply.status == AppOfficialFqdnReply.AOFStatus.AOF_SUCCESS ? FindCloudletReply.FindStatus.FIND_FOUND : FindCloudletReply.FindStatus.FIND_NOTFOUND;
-      fcReply.ports[0] = new AppPort
-      {
-        proto = LProto.L_PROTO_TCP,
-        internal_port = 0,
-        public_port = 0,
-        path_prefix = "",
-        fqdn_prefix = "",
-        end_port = 0,
-        tls = true // FIXME: Unknown channel state!
-      };
 
       return fcReply;
     }

--- a/rest/MatchingEngineSDKRestLibrary/MatchingEngineSDKRestLibrary.csproj
+++ b/rest/MatchingEngineSDKRestLibrary/MatchingEngineSDKRestLibrary.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <ReleaseVersion>2.1.6</ReleaseVersion>
+    <ReleaseVersion>2.1.7</ReleaseVersion>
     <PackOnBuild>true</PackOnBuild>
-    <PackageVersion>2.1.6</PackageVersion>
+    <PackageVersion>2.1.7</PackageVersion>
     <Authors>MobiledgeX, Inc.</Authors>
     <Description>MobiledgeX MatchingEngineSDK Rest Library</Description>
     <Owners>MobiledgeX, Inc.</Owners>
@@ -12,8 +12,8 @@
     <Title>MobiledgeX MatchingEngineSDK Rest Library</Title>
     <PackageId>MobiledgeX.MatchingEngineSDKRestLibrary</PackageId>
     <PackageTags>MobiledgeX MatchingEngine</PackageTags>
-    <AssemblyVersion>2.1.6</AssemblyVersion>
-    <FileVersion>2.1.6</FileVersion>
+    <AssemblyVersion>2.1.7</AssemblyVersion>
+    <FileVersion>2.1.7</FileVersion>
     <Copyright>Copyright 2019 MobiledgeX, Inc. All rights and licenses reserved.</Copyright>
   </PropertyGroup>
 

--- a/rest/RestSample/RestSample.csproj
+++ b/rest/RestSample/RestSample.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
-    <ReleaseVersion>2.1.6</ReleaseVersion>
+    <ReleaseVersion>2.1.7</ReleaseVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\MatchingEngineSDKRestLibrary\MatchingEngineSDKRestLibrary.csproj" />


### PR DESCRIPTION
Bad code for MEL. Now removed. Already in Unity SDK PR, and in C# repo.