### PR TITLE
EDGECLOUD-4350: Do not touch local interface if not MelEnabled in FindCloudlet. Add EnableEnhancedLocationServices mode to MatchingEngine. v2.4.x

### DIFF
--- a/rest/Doxygen/Doxygen.csproj
+++ b/rest/Doxygen/Doxygen.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <RootNamespace>Doxygen</RootNamespace>
-    <ReleaseVersion>2.4.0</ReleaseVersion>
+    <ReleaseVersion>2.4.1</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugType>full</DebugType>

--- a/rest/EngineTests/EngineTests.csproj
+++ b/rest/EngineTests/EngineTests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
-    <ReleaseVersion>2.4.0</ReleaseVersion>
+    <ReleaseVersion>2.4.1</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/rest/MatchingEngineSDK.sln
+++ b/rest/MatchingEngineSDK.sln
@@ -52,7 +52,7 @@ Global
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		description = MatchingEngineSDK Library based on REST backend
-		version = 2.4.0
+		version = 2.4.1
 		Policies = $0
 		$0.DotNetNamingPolicy = $1
 		$1.DirectoryNamespaceAssociation = PrefixedHierarchical

--- a/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
+++ b/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018-2020 MobiledgeX, Inc. All rights and licenses reserved.
+ * Copyright 2018-2021 MobiledgeX, Inc. All rights and licenses reserved.
  * MobiledgeX, Inc. 156 2nd Street #408, San Francisco, CA 94105
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -204,7 +204,14 @@ namespace DistributedMatchEngine
     public DeviceInfo deviceInfo { get; private set; }
     private MelMessagingInterface melMessaging { get; set; }
 
-    DataContractJsonSerializerSettings serializerSettings = new DataContractJsonSerializerSettings
+    /*!
+     * Enable edge features. If enabled, this may cause permission prompts on
+     * some target devices due to the MatchingEngine probing the current network
+     * state for edge capabilities. Edge features may be degraded if not enabled.
+     */
+    public bool EnableEnhancedLocationServices { get; set; } = false;
+
+    internal DataContractJsonSerializerSettings serializerSettings = new DataContractJsonSerializerSettings
     {
       UseSimpleDictionaryFormat = true
     };
@@ -647,7 +654,7 @@ namespace DistributedMatchEngine
 
       if (uid != null && uid != "")
       {
-        request.unique_id_type = "Samsung:SamsungEnablingLayer";
+        request.unique_id_type = "Samsung:" + aUniqueIdType + ":SamsungEnablingLayer";
         request.unique_id = melMessaging.GetUid();
       }
       else if (manufacturer != null &&
@@ -974,7 +981,7 @@ namespace DistributedMatchEngine
       ms = new MemoryStream(byteArray);
       DataContractJsonSerializer deserializer = new DataContractJsonSerializer(typeof(FindCloudletReply), serializerSettings);
       FindCloudletReply reply = (FindCloudletReply)deserializer.ReadObject(ms);
-      if (reply.tags == null)
+      if (reply.tags != null)
       {
         reply.tags = Tag.HashtableToDictionary(reply.htags);
       }
@@ -1084,13 +1091,9 @@ namespace DistributedMatchEngine
      */
     public async Task<FindCloudletReply> FindCloudlet(string host, uint port, FindCloudletRequest request, FindCloudletMode mode = FindCloudletMode.PROXIMITY)
     {
-      string ip = null;
-      if (netInterface.HasWifi())
-      {
-        string wifi = GetAvailableWiFiName(netInterface.GetNetworkInterfaceName());
-        ip = netInterface.GetIPAddress(wifi);
-      }
-      if (melMessaging.IsMelEnabled() && ip == null)
+      if (melMessaging != null && melMessaging.IsMelEnabled() &&
+          netInterface.GetIPAddress(
+            GetAvailableWiFiName(netInterface.GetNetworkInterfaceName())) == null)
       {
         FindCloudletReply melModeFindCloudletReply = await FindCloudletMelMode(host, port, request).ConfigureAwait(false);
         string appOfficialFqdn = melModeFindCloudletReply.fqdn;

--- a/rest/MatchingEngineSDKRestLibrary/MatchingEngineSDKRestLibrary.csproj
+++ b/rest/MatchingEngineSDKRestLibrary/MatchingEngineSDKRestLibrary.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <ReleaseVersion>2.4.0</ReleaseVersion>
+    <ReleaseVersion>2.4.1</ReleaseVersion>
     <PackOnBuild>true</PackOnBuild>
-    <PackageVersion>2.4.0</PackageVersion>
+    <PackageVersion>2.4.1</PackageVersion>
     <Authors>MobiledgeX, Inc.</Authors>
     <Description>MobiledgeX MatchingEngineSDK Rest Library</Description>
     <Owners>MobiledgeX, Inc.</Owners>
@@ -12,8 +12,8 @@
     <Title>MobiledgeX MatchingEngineSDK Rest Library</Title>
     <PackageId>MobiledgeX.MatchingEngineSDKRestLibrary</PackageId>
     <PackageTags>MobiledgeX MatchingEngine</PackageTags>
-    <AssemblyVersion>2.4.0</AssemblyVersion>
-    <FileVersion>2.4.0</FileVersion>
+    <AssemblyVersion>2.4.1</AssemblyVersion>
+    <FileVersion>2.4.1</FileVersion>
     <Copyright>Copyright 2019 MobiledgeX, Inc. All rights and licenses reserved.</Copyright>
   </PropertyGroup>
 

--- a/rest/RestSample/RestSample.csproj
+++ b/rest/RestSample/RestSample.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
-    <ReleaseVersion>2.4.0</ReleaseVersion>
+    <ReleaseVersion>2.4.1</ReleaseVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\MatchingEngineSDKRestLibrary\MatchingEngineSDKRestLibrary.csproj" />


### PR DESCRIPTION
 - Fix "iOS 14.3 Asking for Permission "Connect to Devices on Local Network"
 - This is a minimal fix, as it is partly ad hoc (Permission Request dialogs come upon usage only).
 - Privacy mode needed still if things continue to get tightened.
 - This changes behavior. EdgeMode at least as part of the MobiledgeXIntegration layer in Unity, needs to set a variable
    to allow checking edge capability. On IOS, this is already somewhat limited by the OS already.