### PR TITLE
EDGECLOUD-4350: Do not touch local interface if not MelEnabled in FindCloudlet. Add UseEnhancedLocationServices mode to MatchingEngine. v2.5.1

### DIFF
--- a/grpc/MatchingEngineGrpc/api/DistributedMatchEngine.cs
+++ b/grpc/MatchingEngineGrpc/api/DistributedMatchEngine.cs
@@ -201,6 +201,13 @@ namespace DistributedMatchEngine
 
     public uint dmePort { get; set; } = defaultDmeGrpcPort; // GRPC port
 
+    /*!
+     * Enable edge features. If enabled, this may cause permission prompts on
+     * some target devices due to the MatchingEngine probing the current network
+     * state for edge capabilities. Edge features may be degraded if not enabled.
+     */
+    public static bool EnableEnhancedLocationServices { get; set; } = false;
+
     public CarrierInfo carrierInfo { get; set; }
     public NetInterface netInterface { get; set; }
     public UniqueID uniqueID { get; set; }
@@ -1026,13 +1033,9 @@ namespace DistributedMatchEngine
      */
     public async Task<FindCloudletReply> FindCloudlet(string host, uint port, FindCloudletRequest request, FindCloudletMode mode = FindCloudletMode.PROXIMITY)
     {
-      string ip = null;
-      if (netInterface.HasWifi())
-      {
-        string wifi = GetAvailableWiFiName(netInterface.GetNetworkInterfaceName());
-        ip = netInterface.GetIPAddress(wifi);
-      }
-      if (melMessaging.IsMelEnabled() && ip == null)
+      if (melMessaging != null && melMessaging.IsMelEnabled() &&
+          netInterface.GetIPAddress(
+            GetAvailableWiFiName(netInterface.GetNetworkInterfaceName())) == null)
       {
         FindCloudletReply melModeFindCloudletReply = await FindCloudletMelMode(host, port, request).ConfigureAwait(false);
         if (melModeFindCloudletReply == null)

--- a/rest/Doxygen/Doxygen.csproj
+++ b/rest/Doxygen/Doxygen.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <RootNamespace>Doxygen</RootNamespace>
-    <ReleaseVersion>2.5.0</ReleaseVersion>
+    <ReleaseVersion>2.5.1</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugType>full</DebugType>

--- a/rest/EngineTests/EngineTests.csproj
+++ b/rest/EngineTests/EngineTests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
-    <ReleaseVersion>2.5.0</ReleaseVersion>
+    <ReleaseVersion>2.5.1</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/rest/MatchingEngineSDK.sln
+++ b/rest/MatchingEngineSDK.sln
@@ -52,7 +52,7 @@ Global
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		description = MatchingEngineSDK Library based on REST backend
-		version = 2.5.0
+		version = 2.5.1
 		Policies = $0
 		$0.DotNetNamingPolicy = $1
 		$1.DirectoryNamespaceAssociation = PrefixedHierarchical

--- a/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
+++ b/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
@@ -198,6 +198,13 @@ namespace DistributedMatchEngine
 
     UInt32 dmePort { get; set; } = defaultDmeRestPort; // HTTP REST port
 
+    /*!
+     * Enable edge features. If enabled, this may cause permission prompts on
+     * some target devices due to the MatchingEngine probing the current network
+     * state for edge capabilities. Edge features may be degraded if not enabled.
+     */
+    public static bool EnableEnhancedLocationServices { get; set; } = false;
+
     public CarrierInfo carrierInfo { get; set; }
     public NetInterface netInterface { get; set; }
     public UniqueID uniqueID { get; set; }
@@ -1142,13 +1149,9 @@ namespace DistributedMatchEngine
      */
     public async Task<FindCloudletReply> FindCloudlet(string host, uint port, FindCloudletRequest request, FindCloudletMode mode = FindCloudletMode.PROXIMITY)
     {
-      string ip = null;
-      if (netInterface.HasWifi())
-      {
-        string wifi = GetAvailableWiFiName(netInterface.GetNetworkInterfaceName());
-        ip = netInterface.GetIPAddress(wifi);
-      }
-      if (melMessaging.IsMelEnabled() && ip == null)
+      if (melMessaging != null && melMessaging.IsMelEnabled() &&
+          netInterface.GetIPAddress(
+            GetAvailableWiFiName(netInterface.GetNetworkInterfaceName())) == null)
       {
         FindCloudletReply melModeFindCloudletReply = await FindCloudletMelMode(host, port, request).ConfigureAwait(false);
         if (melModeFindCloudletReply == null)

--- a/rest/MatchingEngineSDKRestLibrary/MatchingEngineSDKRestLibrary.csproj
+++ b/rest/MatchingEngineSDKRestLibrary/MatchingEngineSDKRestLibrary.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <ReleaseVersion>2.5.0</ReleaseVersion>
+    <ReleaseVersion>2.5.1</ReleaseVersion>
     <PackOnBuild>true</PackOnBuild>
-    <PackageVersion>2.5.0</PackageVersion>
+    <PackageVersion>2.5.1</PackageVersion>
     <Authors>MobiledgeX, Inc.</Authors>
     <Description>MobiledgeX MatchingEngineSDK Rest Library</Description>
     <Owners>MobiledgeX, Inc.</Owners>

--- a/rest/RestSample/RestSample.csproj
+++ b/rest/RestSample/RestSample.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
-    <ReleaseVersion>2.5.0</ReleaseVersion>
+    <ReleaseVersion>2.5.1</ReleaseVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\MatchingEngineSDKRestLibrary\MatchingEngineSDKRestLibrary.csproj" />


### PR DESCRIPTION
Same as v2.4.1, except for R3.0. Also checks for a class static "EnableEnhancedLocationServices" permission guard. This is mostly for tracking in Unity, which needs its own changes in IOS and Android.

C# SDK merely helps Unity keep track of the class status. It could vary in implementation per platform, as they all have different permission sets.

Unity SDK needs to implement, C# just stores it for now.

Rebased.