### PR TITLE
Enforce EnableEnhancedLocationServices as a static class boolean

### DIFF
--- a/rest/Doxygen/Doxygen.csproj
+++ b/rest/Doxygen/Doxygen.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <RootNamespace>Doxygen</RootNamespace>
-    <ReleaseVersion>2.4.1</ReleaseVersion>
+    <ReleaseVersion>2.4.2</ReleaseVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugType>full</DebugType>

--- a/rest/EngineTests/EngineTests.csproj
+++ b/rest/EngineTests/EngineTests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
-    <ReleaseVersion>2.4.1</ReleaseVersion>
+    <ReleaseVersion>2.4.2</ReleaseVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/rest/MatchingEngineSDK.sln
+++ b/rest/MatchingEngineSDK.sln
@@ -52,7 +52,7 @@ Global
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		description = MatchingEngineSDK Library based on REST backend
-		version = 2.4.1
+		version = 2.4.2
 		Policies = $0
 		$0.DotNetNamingPolicy = $1
 		$1.DirectoryNamespaceAssociation = PrefixedHierarchical

--- a/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
+++ b/rest/MatchingEngineSDKRestLibrary/DistributedMatchEngine.cs
@@ -209,7 +209,7 @@ namespace DistributedMatchEngine
      * some target devices due to the MatchingEngine probing the current network
      * state for edge capabilities. Edge features may be degraded if not enabled.
      */
-    public bool EnableEnhancedLocationServices { get; set; } = false;
+    public static bool EnableEnhancedLocationServices { get; set; } = false;
 
     internal DataContractJsonSerializerSettings serializerSettings = new DataContractJsonSerializerSettings
     {

--- a/rest/MatchingEngineSDKRestLibrary/MatchingEngineSDKRestLibrary.csproj
+++ b/rest/MatchingEngineSDKRestLibrary/MatchingEngineSDKRestLibrary.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <ReleaseVersion>2.4.1</ReleaseVersion>
+    <ReleaseVersion>2.4.2</ReleaseVersion>
     <PackOnBuild>true</PackOnBuild>
-    <PackageVersion>2.4.1</PackageVersion>
+    <PackageVersion>2.4.2</PackageVersion>
     <Authors>MobiledgeX, Inc.</Authors>
     <Description>MobiledgeX MatchingEngineSDK Rest Library</Description>
     <Owners>MobiledgeX, Inc.</Owners>
@@ -12,8 +12,8 @@
     <Title>MobiledgeX MatchingEngineSDK Rest Library</Title>
     <PackageId>MobiledgeX.MatchingEngineSDKRestLibrary</PackageId>
     <PackageTags>MobiledgeX MatchingEngine</PackageTags>
-    <AssemblyVersion>2.4.1</AssemblyVersion>
-    <FileVersion>2.4.1</FileVersion>
+    <AssemblyVersion>2.4.2</AssemblyVersion>
+    <FileVersion>2.4.2</FileVersion>
     <Copyright>Copyright 2019 MobiledgeX, Inc. All rights and licenses reserved.</Copyright>
   </PropertyGroup>
 

--- a/rest/RestSample/RestSample.csproj
+++ b/rest/RestSample/RestSample.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
-    <ReleaseVersion>2.4.1</ReleaseVersion>
+    <ReleaseVersion>2.4.2</ReleaseVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\MatchingEngineSDKRestLibrary\MatchingEngineSDKRestLibrary.csproj" />


### PR DESCRIPTION
Static class wide boolean to help Unity SDK enforce permissions (per platform specific permission sets).

Moving the needle to 2.4.2.