### PR TITLE
Combine Exceptions into a more informative DmeDnsException. REST and gRPC

### DIFF
--- a/grpc/MatchingEngineGrpc/api/DistributedMatchEngine.cs
+++ b/grpc/MatchingEngineGrpc/api/DistributedMatchEngine.cs
@@ -48,8 +48,8 @@ namespace DistributedMatchEngine
    */
   public class DmeDnsException : Exception
   {
-    public DmeDnsException(string message)
-        : base(message)
+    public DmeDnsException(string message, Exception InnerException = null)
+       : base(message, InnerException)
     {
     }
   }
@@ -471,15 +471,22 @@ namespace DistributedMatchEngine
 
       string potentialDmeHost = mcc + "-" + mnc + "." + baseDmeHost;
 
-      // This host might not actually exist (yet):
-      IPHostEntry ipHostEntry = Dns.GetHostEntry(potentialDmeHost);
-      if (ipHostEntry.AddressList.Length > 0)
+      try
       {
-        return potentialDmeHost;
+        // This host might not actually exist (yet):
+        IPHostEntry ipHostEntry = Dns.GetHostEntry(potentialDmeHost);
+        if (ipHostEntry.AddressList.Length > 0)
+        {
+          return potentialDmeHost;
+        }
+      }
+      catch (Exception e)
+      {
+        throw new DmeDnsException("Cannot generate DME hostname: " + potentialDmeHost + ", Message: " + e.Message, e);
       }
 
       // Let the caller handle an unsupported DME configuration.
-      throw new DmeDnsException("Generated mcc-mnc." + baseDmeHost + " hostname not found: " + potentialDmeHost);
+      throw new DmeDnsException("Generated mcc-mnc. BaseDmeHost: " + baseDmeHost + ", hostname not found: " + potentialDmeHost);
     }
 
     internal string CreateUri(string host, uint port)

--- a/grpc/SampleApp/SampleApp.cs
+++ b/grpc/SampleApp/SampleApp.cs
@@ -78,6 +78,24 @@ namespace MexGrpcSampleConsoleApp
     }
   }
 
+  class DummyCarrierInfo : CarrierInfo
+  {
+    public ulong GetCellID()
+    {
+      return 0;
+    }
+
+    public string GetCurrentCarrierName()
+    {
+      return "26201";
+    }
+
+    public string GetMccMnc()
+    {
+      return "26201";
+    }
+  }
+
   // This interface is optional but is used in the sample.
   class DummyUniqueID : UniqueID
   {
@@ -113,9 +131,9 @@ namespace MexGrpcSampleConsoleApp
     string dmeHost = "192.168.1.172";
     uint dmePort = 50051; // DME port.
     string carrierName = "";
-    string orgName = "mobiledgex";
-    string appName = "arshooter";
-    string appVers = "1";
+    string orgName = "MobiledgeX-Samples";
+    string appName = "ComputerVision";
+    string appVers = "2.2";
 
     MatchingEngine me;
 
@@ -271,7 +289,7 @@ namespace MexGrpcSampleConsoleApp
       {
         me = new MatchingEngine(
           netInterface: new SimpleNetInterface(new MacNetworkInterfaceName()),
-          carrierInfo: new EmptyCarrierInfo(),
+          carrierInfo: new DummyCarrierInfo(),
           deviceInfo: new DummyDeviceInfo(),
           uniqueID: new DummyUniqueID());
         location = GetLocation();
@@ -496,15 +514,16 @@ namespace MexGrpcSampleConsoleApp
     {
       me = new MatchingEngine(
         netInterface: new SimpleNetInterface(new MacNetworkInterfaceName()),
-        carrierInfo: new EmptyCarrierInfo(),
+        carrierInfo: new DummyCarrierInfo(),
         deviceInfo: new DummyDeviceInfo(),
         uniqueID: new DummyUniqueID());
-      me.useSSL = false; // Local testing only.
+      me.useOnlyWifi = true;
+      me.useSSL = true; // false --> Local testing only.
       location = GetLocation();
       string uri = dmeHost + ":" + dmePort;
 
       var registerClientRequest = me.CreateRegisterClientRequest(orgName, appName, appVers);
-      var regReply = await me.RegisterClient(host: dmeHost, port: dmePort, registerClientRequest);
+      var regReply = await me.RegisterClient(registerClientRequest);
 
       Console.WriteLine("RegisterClient Reply Status: " + regReply.Status);
 


### PR DESCRIPTION
See duplicate EnableEnhancedLocationServices in REST master, fixed.

Device Not Configured now. Which is odd, but the error message now has the intended hostname for clarity.