### PR TITLE
EDGECLOUD-5641 IsPingSupported-REST

### DIFF
--- a/rest/EngineTests/UnitTest1.cs
+++ b/rest/EngineTests/UnitTest1.cs
@@ -96,10 +96,14 @@ namespace Tests
 
     class TestDeviceInfo : DeviceInfo
     {
-
       Dictionary<string, string> DeviceInfo.GetDeviceInfo()
       {
         return new Dictionary<string, string>();
+      }
+
+      public bool IsPingSupported()
+      {
+        return false;
       }
     }
 
@@ -682,6 +686,41 @@ namespace Tests
       {
         Console.WriteLine("Timeout test exception " + e.Message);
         Assert.False(e.Message.Contains("Timeout"));
+      }
+    }
+
+
+    [Test]
+    [TestCase(0)]
+    [TestCase(2016)] //Known Port
+    public async static Task TestFindCloudletPerformanceMode(int testPort)
+    {
+      var loc = await Util.GetLocationFromDevice();
+      RegisterClientReply registerReply;
+      FindCloudletReply fcReply;
+      try
+      {
+        RegisterClientRequest registerClientRequest = me.CreateRegisterClientRequest(orgName, appName, appVers);
+        registerReply = await me.RegisterClient(dmeHost, MatchingEngine.defaultDmeRestPort,
+          registerClientRequest
+          );
+        Assert.AreEqual(registerReply.status, ReplyStatus.RsSuccess, "TestFindCloudletPerformanceMode: RegisterClient Failed");
+        FindCloudletRequest fcReq = me.CreateFindCloudletRequest(loc, me.carrierInfo.GetCurrentCarrierName());
+        fcReply = await me.FindCloudletPerformanceMode(dmeHost, MatchingEngine.defaultDmeRestPort,fcReq, testPort: testPort);
+        Assert.AreEqual(fcReply.status, FindCloudletReply.FindStatus.FIND_FOUND, "TestFindCloudletPerformanceMode: FindCloudletPerformanceMode Failed");
+        Assert.NotNull(fcReply.fqdn);
+      }
+      catch (DmeDnsException dde)
+      {
+        Assert.Fail("Workflow DmeDnsException is " + dde);
+      }
+      catch (RegisterClientException rce)
+      {
+        Assert.Fail("Workflow RegisterClientException is " + rce);
+      }
+      catch (FindCloudletException fce)
+      {
+        Assert.Fail("Workflow FindCloudletException is " + fce);
       }
     }
 

--- a/rest/MatchingEngineSDKRestLibrary/DeviceInfo.cs
+++ b/rest/MatchingEngineSDKRestLibrary/DeviceInfo.cs
@@ -23,6 +23,7 @@ namespace DistributedMatchEngine
   public interface DeviceInfo
   {
     Dictionary<string, string> GetDeviceInfo();
+    bool IsPingSupported();
   }
 
   /*!
@@ -34,6 +35,11 @@ namespace DistributedMatchEngine
     public Dictionary<string, string> GetDeviceInfo()
     {
       throw new NotImplementedException("Required DeviceInfo interface function: GetDeviceInfo() is not defined!");
+    }
+
+    public bool IsPingSupported()
+    {
+      throw new NotImplementedException("Required DeviceInfo interface function: IsPingSupported() is not defined!");
     }
   }
 }

--- a/rest/RestSample/RestSample.cs
+++ b/rest/RestSample/RestSample.cs
@@ -46,6 +46,7 @@ namespace RestSample
   class DummyDeviceInfo : DeviceInfo
   {
     DummyCarrierInfo carrierInfo = new DummyCarrierInfo();
+
     Dictionary<string, string> DeviceInfo.GetDeviceInfo()
     {
       Dictionary<string, string> dict = new Dictionary<string, string>();
@@ -55,6 +56,11 @@ namespace RestSample
       dict["DeviceModel"] = "C#SDK";
       dict["DeviceOS"] = "TestOS";
       return dict;
+    }
+
+    public bool IsPingSupported()
+    {
+      return true;
     }
 
   }


### PR DESCRIPTION
-  Added IsPingSupported to DeviceInfo interface as gRPC (iOS AOT doesn't support PING)
- IsPingSupported Check for FindCloudletPerformance.
- Added Unit Test for FCPerformance with the test port.
