### PR TITLE
Third Party Licenses tool and generator for gRPC and REST.

### DIFF
--- a/grpc/Makefile
+++ b/grpc/Makefile
@@ -57,7 +57,7 @@ get-grpc-tools:
 packageRestore:
 	nuget restore
 
-build-all: build-proto build-debug build-release
+build-all: build-proto build-debug build-release third-party-licenses
 
 build-proto:
 	@echo Absolute Path for Proto files are: $(ABSOLUTEPATH)
@@ -81,6 +81,9 @@ publish:
 	echo "Publish command will pause for password if you don't set the Artifactory publish key first..."
 	$(shell nuget push $(BINOUT)/Release/Mobiledgex.MatchingEngineGrpc.$(GRPC_SDK_VERSION).nupkg -Source $(NUGET_RELEASE_SERVER) >> $(PUBLISHLOG))
 
+third-party-licenses:
+	# dotnet tool install --global dotnet-project-licenses to install the tool.
+	dotnet-project-licenses -i MatchingEngineGrpc --include-transitive > THIRD_PARTY_LICENSES.txt
 
 clean:
 ifneq ("$(APPLIBBASE)", "/bin")

--- a/grpc/THIRD_PARTY_LICENSES.txt
+++ b/grpc/THIRD_PARTY_LICENSES.txt
@@ -1,0 +1,92 @@
+
+Project Reference(s) Analysis...
+
+References:
+ | Reference                                           | Version | License Type | License                                                         | 
+ |------------------------------------------------------------------------------------------------------------------------------------------------| 
+ | Google.Protobuf                                     | 3.8.0   |              | https://github.com/protocolbuffers/protobuf/blob/master/LICENSE | 
+ | Grpc                                                | 2.26.0  | Apache-2.0   | https://licenses.nuget.org/Apache-2.0                           | 
+ | Grpc.Core                                           | 2.26.0  | Apache-2.0   | https://licenses.nuget.org/Apache-2.0                           | 
+ | Grpc.Core.Api                                       | 2.26.0  | Apache-2.0   | https://licenses.nuget.org/Apache-2.0                           | 
+ | Microsoft.NETCore.Platforms                         | 1.1.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | Microsoft.NETCore.Platforms                         | 1.0.1   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | Microsoft.NETCore.Targets                           | 1.1.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | Microsoft.NETCore.Targets                           | 1.0.1   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | Microsoft.Win32.Primitives                          | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | NETStandard.Library                                 | 1.6.1   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | runtime.native.System                               | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | runtime.native.System.IO.Compression                | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | runtime.native.System.Net.Http                      | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | runtime.native.System.Security.Cryptography.Apple   | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | runtime.native.System.Security.Cryptography.OpenSsl | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.AppContext                                   | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Buffers                                      | 4.4.0   | MIT          | https://github.com/dotnet/corefx/blob/master/LICENSE.TXT        | 
+ | System.Buffers                                      | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Collections                                  | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Collections.Concurrent                       | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Console                                      | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Diagnostics.Contracts                        | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Diagnostics.Debug                            | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Diagnostics.DiagnosticSource                 | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Diagnostics.Tools                            | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Diagnostics.Tracing                          | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Globalization                                | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Globalization.Calendars                      | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Globalization.Extensions                     | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.IO                                           | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.IO                                           | 4.1.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.IO.Compression                               | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.IO.Compression.ZipFile                       | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.IO.FileSystem                                | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.IO.FileSystem.Primitives                     | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Linq                                         | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Linq.Expressions                             | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Memory                                       | 4.5.3   | MIT          | https://github.com/dotnet/corefx/blob/master/LICENSE.TXT        | 
+ | System.Memory                                       | 4.5.2   | MIT          | https://github.com/dotnet/corefx/blob/master/LICENSE.TXT        | 
+ | System.Net.Http                                     | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Net.Primitives                               | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Net.Sockets                                  | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Numerics.Vectors                             | 4.4.0   | MIT          | https://github.com/dotnet/corefx/blob/master/LICENSE.TXT        | 
+ | System.ObjectModel                                  | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Reflection                                   | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Reflection                                   | 4.1.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Reflection.Emit                              | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Reflection.Emit.ILGeneration                 | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Reflection.Emit.Lightweight                  | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Reflection.Extensions                        | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Reflection.Primitives                        | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Reflection.Primitives                        | 4.0.1   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Reflection.TypeExtensions                    | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Resources.ResourceManager                    | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Runtime                                      | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Runtime                                      | 4.1.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Runtime.CompilerServices.Unsafe              | 4.5.2   | MIT          | https://github.com/dotnet/corefx/blob/master/LICENSE.TXT        | 
+ | System.Runtime.Extensions                           | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Runtime.Handles                              | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Runtime.Handles                              | 4.0.1   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Runtime.InteropServices                      | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Runtime.InteropServices.RuntimeInformation   | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Runtime.Loader                               | 4.0.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Runtime.Numerics                             | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Runtime.WindowsRuntime                       | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Security.Cryptography.Algorithms             | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Security.Cryptography.Cng                    | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Security.Cryptography.Csp                    | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Security.Cryptography.Encoding               | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Security.Cryptography.OpenSsl                | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Security.Cryptography.Primitives             | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Security.Cryptography.X509Certificates       | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Text.Encoding                                | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Text.Encoding                                | 4.0.11  | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Text.Encoding.Extensions                     | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Text.RegularExpressions                      | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Threading                                    | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Threading.Tasks                              | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Threading.Tasks                              | 4.0.11  | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Threading.Tasks.Extensions                   | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Threading.Thread                             | 4.0.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Threading.ThreadPool                         | 4.0.10  | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Threading.Timer                              | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Xml.ReaderWriter                             | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+ | System.Xml.XDocument                                | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                   | 
+

--- a/rest/Makefile
+++ b/rest/Makefile
@@ -33,7 +33,7 @@ all: packageRestore build-all generate-doxygen
 packageRestore:
 	dotnet restore
 
-build-all: build-debug build-release
+build-all: build-debug build-release third-party-licenses
 
 build-debug:
 	@echo Making Debug Library...
@@ -55,6 +55,10 @@ endif
 publish:
 	@echo "Publish command will pause for password if you don't set the Artifactory publish key first..."
 	$(shell nuget push $(BINOUT)/Release/Mobiledgex.MatchingEngineSDKRestLibrary.$(REST_SDK_VERSION).nupkg -Source $(NUGET_RELEASE_SERVER) >> $(PUBLISHLOG))
+
+third-party-licenses:
+	# dotnet tool install --global dotnet-project-licenses to install the tool.
+	dotnet-project-licenses -i MatchingEngineSDKRestLibrary --include-transitive > THIRD_PARTY_LICENSES.txt
 
 clean:
 ifneq ("$(BINOUT)", "/lib")

--- a/rest/THIRD_PARTY_LICENSES.txt
+++ b/rest/THIRD_PARTY_LICENSES.txt
@@ -1,0 +1,73 @@
+
+Project Reference(s) Analysis...
+
+References:
+ | Reference                                           | Version | License Type | License                                                                       | 
+ |--------------------------------------------------------------------------------------------------------------------------------------------------------------| 
+ | Microsoft.NETCore.Platforms                         | 1.1.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | Microsoft.NETCore.Targets                           | 1.1.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | Microsoft.Win32.Primitives                          | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | NETStandard.Library                                 | 1.6.1   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | NuGet.Build.Packaging                               | 0.2.2   |              | https://raw.githubusercontent.com/NuGet/NuGet.Build.Packaging/dev/LICENSE.txt | 
+ | runtime.native.System                               | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | runtime.native.System.IO.Compression                | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | runtime.native.System.Net.Http                      | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | runtime.native.System.Security.Cryptography.Apple   | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | runtime.native.System.Security.Cryptography.OpenSsl | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.AppContext                                   | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Buffers                                      | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Collections                                  | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Collections.Concurrent                       | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Console                                      | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Diagnostics.Contracts                        | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Diagnostics.Debug                            | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Diagnostics.DiagnosticSource                 | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Diagnostics.Tools                            | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Diagnostics.Tracing                          | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Globalization                                | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Globalization.Calendars                      | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Globalization.Extensions                     | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.IO                                           | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.IO.Compression                               | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.IO.Compression.ZipFile                       | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.IO.FileSystem                                | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.IO.FileSystem.Primitives                     | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Json                                         | 4.7.1   | MIT          | https://licenses.nuget.org/MIT                                                | 
+ | System.Linq                                         | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Linq.Expressions                             | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Net.Http                                     | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Net.Primitives                               | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Net.Sockets                                  | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.ObjectModel                                  | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Reflection                                   | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Reflection.Emit                              | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Reflection.Emit.ILGeneration                 | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Reflection.Emit.Lightweight                  | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Reflection.Extensions                        | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Reflection.Primitives                        | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Reflection.TypeExtensions                    | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Resources.ResourceManager                    | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Runtime                                      | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Runtime.Extensions                           | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Runtime.Handles                              | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Runtime.InteropServices                      | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Runtime.InteropServices.RuntimeInformation   | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Runtime.Numerics                             | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Runtime.WindowsRuntime                       | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Security.Cryptography.Algorithms             | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Security.Cryptography.Cng                    | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Security.Cryptography.Csp                    | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Security.Cryptography.Encoding               | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Security.Cryptography.OpenSsl                | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Security.Cryptography.Primitives             | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Security.Cryptography.X509Certificates       | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Text.Encoding                                | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Text.Encoding.Extensions                     | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Text.RegularExpressions                      | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Threading                                    | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Threading.Tasks                              | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Threading.Tasks.Extensions                   | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Threading.Timer                              | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Xml.ReaderWriter                             | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+ | System.Xml.XDocument                                | 4.3.0   | MS-EULA      | http://go.microsoft.com/fwlink/?LinkId=329770                                 | 
+


### PR DESCRIPTION
Pretty straightforward when using a tool right off dotnet's package manager, though not an official Nuget or MS tool. SDK direct dependencies are otherwise, intentionally "thin" for maximum compliance.

Here, the Makefile includes transitive dependencies, which is consistent with Android's official license tool behavior.

